### PR TITLE
Allow group admins to impersonate

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -17,6 +17,11 @@ $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(
 	'OC\Settings\Users::loadAdditionalScripts',
 	function() {
-		\OCP\Util::addScript('impersonate', 'impersonate');
+		$authorized = json_decode(\OC::$server->getConfig()->getAppValue('impersonate', 'authorized', '["admin"]'));
+		$userGroups = \OC::$server->getGroupManager()->getUserGroupIds(\OC::$server->getUserSession()->getUser());
+
+		if (array_intersect($userGroups, $authorized)) {
+			\OCP\Util::addScript('impersonate', 'impersonate');
+		}
 	}
 );

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,18 +20,26 @@ The administrator is then logged-in as the user, to switch back to the regular u
 - This app is not compatible with instances that have encryption enabled.
 - While impersonate actions are logged note that actions performed impersonated will be logged as the impersonated user.
 - Impersonating an user is only possible after their first login.]]></description>
+
     <version>1.1.0</version>
     <licence>agpl</licence>
     <author>Nextcloud</author>
     <namespace>Impersonate</namespace>
+
     <category>tools</category>
     <website>https://github.com/nextcloud/impersonate</website>
     <bugs>https://github.com/nextcloud/impersonate/issues</bugs>
     <repository>https://github.com/nextcloud/impersonate.git</repository>
+
     <screenshot>https://raw.githubusercontent.com/nextcloud/impersonate/master/screenshots/1.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/impersonate/master/screenshots/2.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/impersonate/master/screenshots/3.png</screenshot>
+
     <dependencies>
         <nextcloud min-version="14" max-version="14" />
     </dependencies>
+
+    <settings>
+        <admin>OCA\Impersonate\AdminSettings</admin>
+    </settings>
 </info>

--- a/js/admin_settings.js
+++ b/js/admin_settings.js
@@ -1,0 +1,30 @@
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+$(document).ready(function() {
+	var $authorized = $('#impersonate .authorized');
+
+	OC.Settings.setupGroupsSelect($authorized);
+	$authorized.change(function(event) {
+		var groups = event.val || ['admin'];
+		groups = JSON.stringify(groups);
+		OCP.AppConfig.setValue('impersonate', 'authorized', groups);
+	});
+});

--- a/js/impersonate.js
+++ b/js/impersonate.js
@@ -2,10 +2,6 @@
 (function(OC, $){
 
 	$(document).ready(function() {
-		if(!OC.isUserAdmin()) {
-			return;
-		}
-
 		function impersonate(userId) {
 			$.post(
 				OC.generateUrl('apps/impersonate/user'),

--- a/lib/AdminSettings.php
+++ b/lib/AdminSettings.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Impersonate;
+
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+class AdminSettings implements ISettings {
+
+	/** @var IConfig */
+	protected $config;
+
+	/**
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @return TemplateResponse returns the instance with all parameters set, ready to be rendered
+	 * @since 9.1
+	 */
+	public function getForm() {
+		$authorized = $this->config->getAppValue('impersonate', 'authorized', '["admin"]');
+		return new TemplateResponse('impersonate', 'admin_settings', [
+			'authorized' => implode('|', json_decode($authorized, true)),
+		], 'blank');
+	}
+
+	/**
+	 * @return string the section ID, e.g. 'sharing'
+	 * @since 9.1
+	 */
+	public function getSection() {
+		return 'additional';
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the admin section. The forms are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 *
+	 * E.g.: 70
+	 * @since 9.1
+	 */
+	public function getPriority() {
+		return 50;
+	}
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -11,56 +11,73 @@
 
 namespace OCA\Impersonate\Controller;
 
+use OC\Group\Manager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\AppFramework\Controller;
 use OCP\ISession;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 
 class SettingsController extends Controller {
 	/** @var IUserManager */
 	private $userManager;
+	/** @var IGroupManager|Manager */
+	private $groupManager;
 	/** @var IUserSession */
 	private $userSession;
 	/** @var ISession */
 	private $session;
 	/** @var ILogger */
 	private $logger;
+	/** @var IL10N */
+	private $l;
 
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
 	 * @param IUserSession $userSession
 	 * @param ISession $session
 	 * @param ILogger $logger
+	 * @param IL10N $l
 	 */
 	public function __construct($appName,
 								IRequest $request,
 								IUserManager $userManager,
+								IGroupManager $groupManager,
 								IUserSession $userSession,
 								ISession $session,
-								ILogger $logger) {
+								ILogger $logger,
+								IL10N $l) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->session = $session;
 		$this->logger = $logger;
+		$this->l = $l;
 	}
 
 	/**
 	 * @UseSession
+	 * @NoAdminRequired
 	 *
 	 * @param string $userId
 	 * @return JSONResponse
 	 */
 	public function impersonate($userId) {
-		$oldUserId = $this->userSession->getUser()->getUID();
+		/** @var IUser $currentUser */
+		$currentUser = $this->userSession->getUser();
+
 		if($this->session->get('oldUserId') === null) {
-			$this->session->set('oldUserId', $oldUserId);
+			$this->session->set('oldUserId', $currentUser->getUID());
 		}
 		$this->logger->warning(
 			sprintf(
@@ -80,6 +97,16 @@ class SettingsController extends Controller {
 					'message' => sprintf('No user found for %s', $userId),
 				],
 				Http::STATUS_NOT_FOUND
+			);
+		}
+
+		if (!$this->groupManager->isAdmin($currentUser->getUID())
+			&& !$this->groupManager->getSubAdmin()->isUserAccessible($currentUser, $user)) {
+			return new JSONResponse(
+				[
+					'message' => $this->l->t('Not enough permissions to impersonate user'),
+				],
+				Http::STATUS_FORBIDDEN
 			);
 		}
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -94,7 +94,7 @@ class SettingsController extends Controller {
 		if ($user === null) {
 			return new JSONResponse(
 				[
-					'message' => sprintf('No user found for %s', $userId),
+					'message' => $this->l->t('User not found'),
 				],
 				Http::STATUS_NOT_FOUND
 			);
@@ -113,7 +113,7 @@ class SettingsController extends Controller {
 		if ($user->getLastLogin() === 0) {
 			return new JSONResponse(
 				[
-					'message' => sprintf('Can\'t impersonate %s, user has to be logged in at least once.', $userId),
+					'message' => $this->l->t('Can not impersonate the user because it was never logged in.'),
 				],
 				Http::STATUS_FORBIDDEN
 			);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -88,7 +88,7 @@ class SettingsController extends Controller {
 		$this->logger->warning(
 			sprintf(
 				'User %s trying to impersonate user %s',
-				$oldUserId,
+				$currentUser->getUID(),
 				$userId
 				),
 				[

--- a/templates/admin_settings.php
+++ b/templates/admin_settings.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+script('impersonate', 'admin_settings');
+
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
+?>
+<div id="impersonate" class="section">
+	<h2 class="inlineblock"><?php p($l->t('Impersonate')); ?></h2>
+
+	<p>
+		<input type="hidden" name="authorized" class="authorized" value="<?php p($_['authorized']) ?>" style="width: 320px;" />
+		<br />
+		<em><?php p($l->t('These groups will be able to impersonate users they are allowed to administrate.')); ?></em>
+	</p>
+</div>

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -11,12 +11,18 @@
 
 namespace OCA\Impersonate\Tests\Controller;
 
+use OC\Group\Manager;
+use OC\SubAdmin;
 use OCA\Impersonate\Controller\SettingsController;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ILogger;
 use OCP\ISession;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Test\TestCase;
@@ -34,33 +40,56 @@ class SettingsControllerTest extends TestCase {
 	private $request;
 	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
+	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $groupManager;
+	/** @var SubAdmin|\PHPUnit_Framework_MockObject_MockObject */
+	private $subadmin;
 	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	private $userSession;
-	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
-	private $logger;
 	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
 	private $session;
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	private $l;
 	/** @var SettingsController */
 	private $controller;
 
 	public function setUp() {
+		parent::setUp();
+
 		$this->appName = 'impersonate';
 		$this->request = $this->createMock(IRequest::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(Manager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->logger = $this->createMock(ILogger::class);
 		$this->session = $this->createMock(ISession::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->l = $this->createMock(IL10N::class);
+		$this->l->expects($this->any())
+			->method('t')
+			->will($this->returnCallback(function($text, $parameters = array()) {
+				return vsprintf($text, $parameters);
+			}));
+		$this->subadmin = $this->createMock(SubAdmin::class);
+		$this->groupManager->expects($this->any())
+			->method('getSubAdmin')
+			->willReturn($this->subadmin);
 
 		$this->controller = new SettingsController(
 			$this->appName,
 			$this->request,
 			$this->userManager,
+			$this->groupManager,
 			$this->userSession,
 			$this->session,
-			$this->logger
+			$this->config,
+			$this->logger,
+			$this->l
 		);
-
-		parent::setUp();
 	}
 
 	public function testImpersonateNotFound() {
@@ -75,7 +104,7 @@ class SettingsControllerTest extends TestCase {
 			->method('setUser');
 
 		$this->assertEquals(
-			new JSONResponse(['message' => 'No user found for notexisting@uid'], Http::STATUS_NOT_FOUND),
+			new JSONResponse(['message' => 'User not found'], Http::STATUS_NOT_FOUND),
 			$this->controller->impersonate('notexisting@uid')
 		);
 	}
@@ -86,72 +115,27 @@ class SettingsControllerTest extends TestCase {
 			['UserName', 'username']
 		];
 	}
+
 	/**
 	 * @dataProvider usersProvider
 	 * @param $query
 	 * @param $uid
 	 */
-	public function testImpersonate($query, $uid) {
-		$user = $this->createMock('\OCP\IUser');
-		$user->method('getUID')
-			->willReturn($uid);
-
-		$this->userSession
-			->method('getUser')
-			->willReturn($user);
-
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with($query)
-			->willReturn($user);
-
-		$this->userSession->expects($this->once())
-			->method('setUser')
-			->with($user);
-
-		$this->assertEquals(
-			new JSONResponse(),
-			$this->controller->impersonate($query)
-		);
-	}
-
-	public function normalUsers() {
-		return [
-			['username', 'username'],
-			['UserName', 'username']
-		];
-	}
-
-	/**
-	 * @dataProvider normalUsers
-	 * @param $query
-	 */
-
-	public function testAdminImpersonateNormalUsers($query,$uid) {
-		$loggedInUser = $this->createMock('OCP\IUser');
-		$loggedInUser
-			->expects($this->once())
+	public function testAdminImpersonate($query, $uid) {
+		$currentUser = $this->createMock(IUser::class);
+		$currentUser->expects($this->any())
 			->method('getUID')
 			->willReturn('admin');
 
-		$this->userSession
-			->expects($this->once())
-			->method('getUser')
-			->willReturn($loggedInUser);
-
-		$userManager = $this->getMockBuilder('OC\User\Manager')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$userManager->expects($this->any())
-			->method('createUser')
-			->with($query,'123');
-
-		$user = $this->createMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn($uid);
 
+		$this->userSession
+			->method('getUser')
+			->willReturn($currentUser);
+
 		$this->userManager->expects($this->once())
 			->method('get')
 			->with($query)
@@ -161,10 +145,179 @@ class SettingsControllerTest extends TestCase {
 			->method('setUser')
 			->with($user);
 
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('admin')
+			->willReturn(true);
+
+		$this->groupManager->expects($this->once())
+			->method('getUserGroupIds')
+			->with($currentUser)
+			->willReturn(['admin']);
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('impersonate', 'authorized', '["admin"]')
+			->willReturnArgument(2);
+
 		$this->assertEquals(
 			new JSONResponse(),
 			$this->controller->impersonate($query)
 		);
 	}
 
+	/**
+	 * @dataProvider usersProvider
+	 * @param $query
+	 * @param $uid
+	 */
+	public function testSubAdminImpersonate($query, $uid) {
+		$currentUser = $this->createMock(IUser::class);
+		$currentUser->expects($this->any())
+			->method('getUID')
+			->willReturn('admin');
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn($uid);
+
+		$this->userSession
+			->method('getUser')
+			->willReturn($currentUser);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($query)
+			->willReturn($user);
+
+		$this->userSession->expects($this->once())
+			->method('setUser')
+			->with($user);
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('admin')
+			->willReturn(false);
+
+		$this->subadmin->expects($this->once())
+			->method('isUserAccessible')
+			->with($currentUser, $user)
+			->willReturn(true);
+
+		$this->groupManager->expects($this->once())
+			->method('getUserGroupIds')
+			->with($currentUser)
+			->willReturn(['subadmin']);
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('impersonate', 'authorized', '["admin"]')
+			->willReturn(json_encode(['admin', 'subadmin']));
+
+		$this->assertEquals(
+			new JSONResponse(),
+			$this->controller->impersonate($query)
+		);
+	}
+
+	/**
+	 * @dataProvider usersProvider
+	 * @param $query
+	 * @param $uid
+	 */
+	public function testSubAdminImpersonateNotAllowed($query, $uid) {
+		$currentUser = $this->createMock(IUser::class);
+		$currentUser->expects($this->any())
+			->method('getUID')
+			->willReturn('admin');
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn($uid);
+
+		$this->userSession
+			->method('getUser')
+			->willReturn($currentUser);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($query)
+			->willReturn($user);
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('admin')
+			->willReturn(false);
+
+		$this->subadmin->expects($this->once())
+			->method('isUserAccessible')
+			->with($currentUser, $user)
+			->willReturn(true);
+
+		$this->userSession->expects($this->never())
+			->method('setUser')
+			->with($user);
+
+		$this->groupManager->expects($this->once())
+			->method('getUserGroupIds')
+			->with($currentUser)
+			->willReturn(['subadmin']);
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('impersonate', 'authorized', '["admin"]')
+			->willReturnArgument(2);
+
+		$this->assertEquals(
+			new JSONResponse(['message' => 'Not enough permissions to impersonate user'], Http::STATUS_FORBIDDEN),
+			$this->controller->impersonate($query)
+		);
+	}
+
+	/**
+	 * @dataProvider usersProvider
+	 * @param $query
+	 * @param $uid
+	 */
+	public function testSubAdminImpersonateNotAccessible($query, $uid) {
+		$currentUser = $this->createMock(IUser::class);
+		$currentUser->expects($this->any())
+			->method('getUID')
+			->willReturn('admin');
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn($uid);
+
+		$this->userSession
+			->method('getUser')
+			->willReturn($currentUser);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($query)
+			->willReturn($user);
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('admin')
+			->willReturn(false);
+
+		$this->subadmin->expects($this->once())
+			->method('isUserAccessible')
+			->with($currentUser, $user)
+			->willReturn(false);
+
+		$this->userSession->expects($this->never())
+			->method('setUser')
+			->with($user);
+
+		$this->assertEquals(
+			new JSONResponse(['message' => 'Not enough permissions to impersonate user'], Http::STATUS_FORBIDDEN),
+			$this->controller->impersonate($query)
+		);
+	}
 }


### PR DESCRIPTION
Fix #25 

- [x] Based on #27 
- [x] Load JS for subadmins
- [x] Allow and test the functionality for subadmins
- [x] Make it possible to define the list of subadmins which can impersonate