### PR TITLE
load impersonate script when no restrictions apply

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -18,9 +18,15 @@ $eventDispatcher->addListener(
 	'OC\Settings\Users::loadAdditionalScripts',
 	function() {
 		$authorized = json_decode(\OC::$server->getConfig()->getAppValue('impersonate', 'authorized', '["admin"]'));
-		$userGroups = \OC::$server->getGroupManager()->getUserGroupIds(\OC::$server->getUserSession()->getUser());
 
-		if (array_intersect($userGroups, $authorized)) {
+		$loadScript = true;
+		if(!empty($authorized)) {
+			$userGroups = \OC::$server->getGroupManager()->getUserGroupIds(\OC::$server->getUserSession()->getUser());
+			if (!array_intersect($userGroups, $authorized)) {
+				$loadScript = false;
+			}
+		}
+		if($loadScript){
 			\OCP\Util::addScript('impersonate', 'impersonate');
 		}
 	}


### PR DESCRIPTION
1. lift restrictions for impersonating (aka remove all groups)
2. login as group admin, go to users
3. with  intention of impersonating, open the three-dot-menu
4. 👀

in app.php was another check that needed adjustment. 

This needs to  go  to master only,  for stable 13 included in #44 