### PR TITLE
users shall not impersonate themselves

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -82,9 +82,6 @@ class SettingsController extends Controller {
 		/** @var IUser $currentUser */
 		$currentUser = $this->userSession->getUser();
 
-		if($this->session->get('oldUserId') === null) {
-			$this->session->set('oldUserId', $currentUser->getUID());
-		}
 		$this->logger->warning(
 			sprintf(
 				'User %s trying to impersonate user %s',
@@ -139,6 +136,15 @@ class SettingsController extends Controller {
 			);
 		}
 
+		if ($user->getUID() === $currentUser->getUID()) {
+			return new JSONResponse(
+				[
+					'message' => $this->l->t('Can not impersonate yourself.'),
+				],
+				Http::STATUS_FORBIDDEN
+			);
+		}
+
 		$this->logger->warning(
 			sprintf(
 				'Changing to user %s',
@@ -148,6 +154,9 @@ class SettingsController extends Controller {
 				'app' => 'impersonate',
 			]
 		);
+		if($this->session->get('oldUserId') === null) {
+			$this->session->set('oldUserId', $currentUser->getUID());
+		}
 		$this->userSession->setUser($user);
 		return new JSONResponse();
 	}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -87,10 +87,10 @@ class SettingsController extends Controller {
 				'User %s trying to impersonate user %s',
 				$currentUser->getUID(),
 				$userId
-				),
-				[
-					'app' => 'impersonate',
-				]
+			),
+			[
+				'app' => 'impersonate',
+			]
 		);
 
 		$user = $this->userManager->get($userId);
@@ -154,7 +154,7 @@ class SettingsController extends Controller {
 				'app' => 'impersonate',
 			]
 		);
-		if($this->session->get('oldUserId') === null) {
+		if ($this->session->get('oldUserId') === null) {
 			$this->session->set('oldUserId', $currentUser->getUID());
 		}
 		$this->userSession->setUser($user);


### PR DESCRIPTION
fixes #93 

also sets the session var indicating that impersonification is happening only after successful checks. Might fix #96.