### PR TITLE
fix(frontend): fix determining user id

### DIFF
--- a/js/impersonate.js
+++ b/js/impersonate.js
@@ -16,14 +16,13 @@
 		xhr.send('userId=' + encodeURIComponent(userId) + '&requesttoken=' + encodeURIComponent(OC.requestToken))
 	}
 
-	function impersonateDialog(event) {
-		var userId = event.target.closest('.row').dataset.id
+	function impersonateDialog(event, user) {
 		OC.dialogs.confirm(
-			t('impersonate', 'Are you sure you want to impersonate "{userId}"?', { userId: userId }),
+			t('impersonate', 'Are you sure you want to impersonate "{userId}"?', { userId: user.id }),
 			t('impersonate', 'Impersonate user'),
 			function(result) {
 				if (result) {
-					impersonate(userId)
+					impersonate(user.id)
 				}
 			},
 			true


### PR DESCRIPTION
* [x] requires https://github.com/nextcloud/server/pull/41349 – thank you @susnux !

after structural changes on the popup menu on the user page, the required user id could not be determined via HTML anymore. Now the user object is passed with the triggered action and can be utilized.