### PR TITLE
Support delegated admin

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -74,6 +74,7 @@ class SettingsController extends Controller {
 		}
 
 		if (!$this->groupManager->isAdmin($impersonator->getUID())
+			&& !$this->groupManager->isDelegatedAdmin($impersonator->getUID())
 			&& !$this->groupManager->getSubAdmin()->isUserAccessible($impersonator, $impersonatee)) {
 			return new JSONResponse(
 				[


### PR DESCRIPTION
Since Nextcloud 30.0.0, we can delegate users administration to non-admin groups.
This pull request adds this feature support in the impersonate app