### PR TITLE
fix(settings): close the admin settings container div

### DIFF
--- a/templates/admin_settings.php
+++ b/templates/admin_settings.php
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 ?>
-<div id="impersonate"</div>
+<div id="impersonate"></div>


### PR DESCRIPTION
Fixes #677.

### The bug

`templates/admin_settings.php` renders

```php
<div id="impersonate"</div>
```

The opening tag is never closed. The HTML parser consumes `</div>` as bogus attributes, so the element stays open and **every sibling rendered after it becomes its child**.

The settings app concatenates all forms of a section into one container, so with Impersonate enabled the admin settings content looks like this:

```html
<div id="original-settings-content">
	<div id="impersonate"</div>
<div id="quota_warning_quota_warning"></div><div id="auto_groups_auto_groups"></div></div>
```

`src/mainAdminSettings.js` then mounts the Vue app on `#impersonate`, which replaces that element's subtree — taking the other apps' mount points with it.

### Why it is silent

Declarative settings forms mount into `<div id="{app}_{form}"></div>` placeholders emitted by `CommonSettingsTrait::formatSettings()`. A production Vue build mounting on a missing element renders into a detached node without warning, so the affected sections vanish with no console error, no server-side error and nothing in `nextcloud.log`. The initial state and the JS bundle are both present and correct, which makes this quite hard to track down from the symptom.

### Effect

Every settings form rendered after Impersonate in the same section disappears. On Nextcloud 34 with Impersonate 5.0.0 that was Auto Groups and Quota Warning here; #677 additionally reports Announcement Center. Disabling Impersonate makes them reappear, which is the workaround people have been using.

### The fix

One character — close the tag. Verified on Nextcloud 34.0.3: with the patch applied the container renders

```html
<div id="impersonate"></div><div id="quota_warning_quota_warning"></div><div id="auto_groups_auto_groups"></div>
```

and both previously invisible sections render again, Impersonate included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)